### PR TITLE
fix: Order filter is now working

### DIFF
--- a/server/api/search/by-filter.post.ts
+++ b/server/api/search/by-filter.post.ts
@@ -53,7 +53,17 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  const search = await searchAnimesByFilter({ ...body, order, page });
+  const orderKeyMap: Record<string, string> = {
+    default: "Por Defecto",
+    updated: "Recientemente Actualizados",
+    added: "Recientemente Agregados",
+    title: "Nombre A-Z",
+    rating: "Calificación"
+  };
+
+  const mappedOrder = orderKeyMap[order];
+
+  const search = await searchAnimesByFilter({ ...body, order: mappedOrder, page });
   if (!search || !search?.media?.length) {
     throw createError({
       statusCode: 404,


### PR DESCRIPTION
Se corrige el uso del parámetro `order` en el endpoint de búsqueda.

Antes, se pasaba `"title"`, `"rating"`, etc., pero `searchAnimesByFilter` espera los valores como `"Nombre A-Z"`, `"Calificación"`, etc. Ahora se mapea correctamente antes de llamar a la función.

Esto permite que el filtro de orden funcione como se espera desde la query.
